### PR TITLE
Switched data type to sensitive

### DIFF
--- a/tasks/encrypt.json
+++ b/tasks/encrypt.json
@@ -5,7 +5,7 @@
     "parameters": {
         "data": {
             "description": "The content you want to encrypt",
-            "type": "String[1]"
+            "type": "Sensitive[String[1]]"
         }
     }
 }

--- a/tasks/encrypt.json
+++ b/tasks/encrypt.json
@@ -5,7 +5,8 @@
     "parameters": {
         "data": {
             "description": "The content you want to encrypt",
-            "type": "Sensitive[String[1]]"
+            "type": "String[1]",
+            "sensitive": true
         }
     }
 }


### PR DESCRIPTION
Change data type to sensitive. 

This blanks out the plaintext so it cannot be viewed in the PE console or logs. Many users require this as they may be encrypting password and other sensitive data. 